### PR TITLE
Added indexing of Circuits, appending of CircuitGateChains, approx of…

### DIFF
--- a/src/Qaintessent.jl
+++ b/src/Qaintessent.jl
@@ -38,7 +38,8 @@ export
     rdm,
     CircuitGateChain,
     MeasurementOps,
-    Circuit
+    Circuit,
+    distribution
 
 include("apply.jl")
 export


### PR DESCRIPTION
Added indexing of Circuits:
Circuits[i] = Circuits.cgc[i]

Added appending of CGC
cgc = cgc1 * cgc2 -> Only allows appending if share {N} wires

Added approx comparison of cg gates
cg \approx cg will compare all fields and match them if the two gates are of the same type.