### PR TITLE
Add functionality, so that c::Circuit(\psi::AbstractVector) is equiva…

### DIFF
--- a/src/apply.jl
+++ b/src/apply.jl
@@ -228,3 +228,5 @@ function apply(c::Circuit{N}, ψ::AbstractVector) where {N}
     ψs = apply(c.cgc, ψ)
     return [real(dot(ψs, m*ψs)) for m in c.meas.mops]
 end
+
+(c::Circuit)(ψ) = apply(c, ψ)


### PR DESCRIPTION
Add functionality, so that c::Circuit(\psi::AbstractVector) is equivalent to apply(c::Circuit, \psi::AbstractVector)