### PR TITLE
added MatrixGate

### DIFF
--- a/src/Qaintessent.jl
+++ b/src/Qaintessent.jl
@@ -25,7 +25,8 @@ export
     PhaseShiftGate,
     SwapGate,
     ControlledGate,
-    controlled_not
+    controlled_not,
+    MatrixGate
 
 
 include("circuit.jl")

--- a/src/gates.jl
+++ b/src/gates.jl
@@ -241,3 +241,17 @@ end
 Base.adjoint(g::ControlledGate{M,N}) where {M,N} = ControlledGate{M,N}(Base.adjoint(g.U))
 
 controlled_not() = ControlledGate{1,2}(X)
+
+struct MatrixGate{N} <: AbstractGate{N}
+    matrix::AbstractMatrix
+    function MatrixGate(m)
+        d = 2
+        @assert size(m,1) == size(m,2)
+        N = Int(log(d, size(m,1)))
+        return new{N}(m)
+    end
+end
+
+function matrix(MG::MatrixGate{N}) where N
+    MG.matrix
+end


### PR DESCRIPTION
I added a MatrixGate <: AbstractGate with the purpose of creating a gate type from a matrix. The motivation comes from computing expectation values of an operator given in a matrix form by using the tensor_circuit function. This way is very simple to create user defined gates and can be done inside functions. 