### PR TITLE
Documentation

### DIFF
--- a/docs/src/models.md
+++ b/docs/src/models.md
@@ -6,9 +6,86 @@ CurrentModule = Qaintessent
 
 ```@docs
 qft_circuit(N::Integer)
+```
+```@docs
 toffoli_circuit(cntrl::Tuple{<:Integer, <:Integer} , trg::Integer, N::Integer)
+```
+
+```@docs
 vbe_adder_circuit(N::Integer)
+```
+#### Example
+```jldoctest
+using Qaintessent 
+
+N = 3
+M = N*3 + 1
+
+adder = vbe_adder_circuit(N)
+ψ = fill(0.0+0.0*im, 2^M)
+a = 1
+b = 3
+
+index = b << N + a
+ψ[index+1] = 1.0
+
+ψ = apply(adder, ψ)
+((findall(x->x==1, ψ)[1]-1)%(2^2N)) >> N
+
+# output
+
+4
+```
+
+```@docs
 qcla_out_adder_circuit(N::Integer)
+```
+#### Example
+```jldoctest
+using Qaintessent 
+
+N = 3
+M = 3N + 1
+
+adder = qcla_out_adder_circuit(N)
+ψ = fill(0.0+0.0*im, 2^M)
+a = 2
+b = 3
+
+index = b << N + a
+ψ[index+1] = 1.0
+
+ψ = apply(adder, ψ)
+(findall(x->x==1, ψ)[1] - 1) >> 2N
+
+# output
+
+5
+```
+
+```@docs
 qcla_inplace_adder_circuit(N::Integer)
+```
+#### Example
+```jldoctest
+using Qaintessent 
+
+N = 3
+M = 3N
+
+adder = qcla_inplace_adder_circuit(N)
+ψ = fill(0.0+0.0*im, 2^M)
+a = 1
+b = 2
+
+index = b << N + a
+ψ[index+1] = 1.0
+
+ψ = apply(adder, ψ)
+(findall(x->x==1, ψ)[1] - 1) >> N
+
+# output
+
+3
 ```
 

--- a/src/models.jl
+++ b/src/models.jl
@@ -57,8 +57,6 @@ The input index should be ``a_{0}a_{1}a_{2}..a_{N}b_{0}b_{1}b_{2}..b_{N} + 1`` w
 The output index will be in the form ``a_{0}a_{1}a_{2}..a_{N}c_{0}c_{1}c_{2}..c_{N} + 1`` where:
 
 ``C = (A+B) \\% (2^{N} + 1) = c_{0}\\times 2^{0} + c_{1} \\times 2^{1} + c_{2} \\times 2^{2} + ... + c_{N} \\times 2^{N}``
-
-An example of the code can be seen below
 """
 function vbe_adder_circuit(N::Integer)
     M = 3*N + 1
@@ -202,8 +200,6 @@ The input index should be ``a_{0}a_{1}a_{2}..a_{N}b_{0}b_{1}b_{2}..b_{N} + 1`` a
 The output index will be in the form ``a_{0}a_{1}a_{2}..a_{N}b_{0}b_{1}b_{2}..b_{N}c_{0}c_{1}c_{2}..c_{N+1} + 1`` where:
 
 ``C = A+B = c_{0}\\times 2^{0} + c_{1} \\times 2^{1} + c_{2} \\times 2^{2} + ... + c_{N+1} \\times 2^{N+1}``
-
-An example of the code can be seen below
 """
 function qcla_out_adder_circuit(N)
 

--- a/src/models.jl
+++ b/src/models.jl
@@ -59,26 +59,6 @@ The output index will be in the form ``a_{0}a_{1}a_{2}..a_{N}c_{0}c_{1}c_{2}..c_
 ``C = (A+B) \\% (2^{N} + 1) = c_{0}\\times 2^{0} + c_{1} \\times 2^{1} + c_{2} \\times 2^{2} + ... + c_{N} \\times 2^{N}``
 
 An example of the code can be seen below
-
-# Examples
-
-```jldoctest
-N = 4
-adder = vbe_adder_circuit(N)
-ψ = fill(0.0+0.0*im, 2^M)
-a = 3
-b = 5
-
-index = b << N + a
-ψ[index+1] = 1.0
-
-ψ = apply(adder, ψ)
-((findall(x->x==1, ψ)[1]-1)%(2^2N)) >> N
-
-# output
-
-8
-```
 """
 function vbe_adder_circuit(N::Integer)
     M = 3*N + 1
@@ -224,28 +204,6 @@ The output index will be in the form ``a_{0}a_{1}a_{2}..a_{N}b_{0}b_{1}b_{2}..b_
 ``C = A+B = c_{0}\\times 2^{0} + c_{1} \\times 2^{1} + c_{2} \\times 2^{2} + ... + c_{N+1} \\times 2^{N+1}``
 
 An example of the code can be seen below
-
-# Examples
-
-```jldoctest
-N = 4
-adder = qcla_out_adder_circuit(N)
-ψ = fill(0.0+0.0*im, 2^M)
-a = 2
-b = 6
-
-index = b << N + a
-ψ = fill(0.0+0.0*im, 2^M)
-
-ψ[index+1] = 1.0
-
-ψ = apply(cgc, ψ)
-(findall(x->x==1, ψ)[1] - 1) >> 2N
-
-# output
-
-8
-```
 """
 function qcla_out_adder_circuit(N)
 
@@ -335,31 +293,9 @@ If the two added integers are represented as:
 
 The input index should be ``a_{0}a_{1}a_{2}..a_{N}b_{0}b_{1}b_{2}..b_{N} + 1`` as Julia starts indexing at `1` and ``a_{0}`` as the fastest running index
 
-The output index will be in the form ``a_{0}a_{1}a_{2}..a_{N}b_{0}c_{1}c_{2}..c_{N+1} + 1`` where:
+The output index will be in the form ``a_{0}a_{1}a_{2}..a_{N}c_{0}c_{1}c_{2}..c_{N+1} + 1`` where:
 
 ``C = A+B = c_{0}\\times 2^{0} + c_{1} \\times 2^{1} + c_{2} \\times 2^{2} + ... + c_{N+1} \\times 2^{N+1}``
-
-# Examples
-
-```jldoctest
-N = 4
-adder = qcla_out_adder_circuit(N)
-ψ = fill(0.0+0.0*im, 2^M)
-a = 2
-b = 3
-
-index = b << N + a
-ψ = fill(0.0+0.0*im, 2^M)
-
-ψ[index+1] = 1.0
-
-ψ = apply(cgc, ψ)
-(findall(x->x==1, ψ)[1] - 1) >> 2N
-
-# output
-
-5
-```
 """
 function qcla_inplace_adder_circuit(N)
 


### PR DESCRIPTION
Shifted doctests to the documentation. These should run when generating documentation to ensure that the syntax remains the same! Should not be treated as unit-tests