### PR TITLE
Fix view for MatrixGate

### DIFF
--- a/src/view.jl
+++ b/src/view.jl
@@ -55,6 +55,14 @@ function view(g::SwapGate, i::Vector{Int64})
     ["——x———", "——x———"], i
 end
 
+function Qaintessent.view(g::MatrixGate, i::Vector{Int64})
+  if length(i) == 1
+      return ["——□———"], i
+  else
+      return ["——□———", "——□———"], i
+  end
+end
+
 view(g) = view(g, [1])
 
 Base.size(g::AbstractGate{N}) where {N} = N

--- a/src/view.jl
+++ b/src/view.jl
@@ -55,14 +55,6 @@ function view(g::SwapGate, i::Vector{Int64})
     ["——x———", "——x———"], i
 end
 
-function Qaintessent.view(g::AbstractGate, i::Vector{Int64})
-  if length(i) == 1
-      return ["——□———"], i
-  else
-      return ["——□———", "——□———"], i
-  end
-end
-
 view(g) = view(g, [1])
 
 Base.size(g::AbstractGate{N}) where {N} = N
@@ -71,6 +63,10 @@ function view(g::ControlledGate, i::Vector{Int64})
     gate = fill("——•———", length(i))
     gate[end-Base.size(g.U)+1:end] = view(g.U)[1]
     return gate, i
+end
+
+function view(g::AbstractGate, i::Vector{Int64})
+    fill("——□———", length(i)), i
 end
 
 function interleave(a::Vector{T}, b::Vector{T}) where {T}

--- a/src/view.jl
+++ b/src/view.jl
@@ -55,7 +55,7 @@ function view(g::SwapGate, i::Vector{Int64})
     ["——x———", "——x———"], i
 end
 
-function Qaintessent.view(g::MatrixGate, i::Vector{Int64})
+function Qaintessent.view(g::AbstractGate, i::Vector{Int64})
   if length(i) == 1
       return ["——□———"], i
   else

--- a/test/test_view.jl
+++ b/test/test_view.jl
@@ -8,6 +8,7 @@ using Qaintessent
     N = 5
     cgc = CircuitGateChain{N}([
         single_qubit_circuit_gate(3, HadamardGate(), N),
+        single_qubit_circuit_gate(5, MatrixGate([0 1;1 0]), N),
         controlled_circuit_gate((1, 4), 2, RxGate(√0.2), N),
         controlled_circuit_gate((2,4), (1,5), SwapGate(), N),
         single_qubit_circuit_gate(2, PhaseShiftGate(0.2π), N),
@@ -27,7 +28,7 @@ using Qaintessent
         "              |     |           |   \n" *
         "    4 ————————•—————•———————————•———\n" *
         "                    |           |   \n" *
-        "    5 ——————————————x———————————x———\n"
+        "    5 ——□———————————x———————————x———\n"
 
     io = IOBuffer()
     show(io, cgc)

--- a/test/test_view.jl
+++ b/test/test_view.jl
@@ -6,29 +6,34 @@ using Qaintessent
 @testset ExtendedTestSet "test view" begin
 
     N = 5
+    A = [1 0; 0 -1]
+    MG = kron(A, kron(A, A))
+
     cgc = CircuitGateChain{N}([
-        single_qubit_circuit_gate(3, HadamardGate(), N),
-        single_qubit_circuit_gate(5, MatrixGate([0 1;1 0]), N),
-        controlled_circuit_gate((1, 4), 2, RxGate(√0.2), N),
-        controlled_circuit_gate((2,4), (1,5), SwapGate(), N),
-        single_qubit_circuit_gate(2, PhaseShiftGate(0.2π), N),
-        single_qubit_circuit_gate(3, RotationGate(0.1π, [1, 0, 0]), N),
-        single_qubit_circuit_gate(1, RyGate(1.4π), N),
-        two_qubit_circuit_gate(1,2, SwapGate(), N),
-        controlled_circuit_gate(4, (3,5), SwapGate(), N),
+    single_qubit_circuit_gate(3, HadamardGate(), N),
+    controlled_circuit_gate((1, 4), 2, RxGate(√0.2), N),
+    controlled_circuit_gate((2,4), (1,5), SwapGate(), N),
+    single_qubit_circuit_gate(2, PhaseShiftGate(0.2π), N),
+    single_qubit_circuit_gate(3, RotationGate(0.1π, [1, 0, 0]), N),
+    single_qubit_circuit_gate(1, RyGate(1.4π), N),
+    two_qubit_circuit_gate(1,2, SwapGate(), N),
+    controlled_circuit_gate(4, 5, TdagGate(), N),
+    single_qubit_circuit_gate(3, SGate(), N),
+    single_qubit_circuit_gate(1, MatrixGate(A), N),
+    CircuitGate{3,N,AbstractGate{3}}((2, 4, 5), MatrixGate(MG))
     ])
 
     cgc_refstring =
         "\n" *
-        "    1 ————————•—————x————[Ry]———x———\n" *
-        "              |     |           |   \n" *
-        "    2 ———————[Rx]———•————[Pϕ]———x———\n" *
-        "              |     |               \n" *
-        "    3 —[H ]——————————————[Rθ]———x———\n" *
-        "              |     |           |   \n" *
-        "    4 ————————•—————•———————————•———\n" *
-        "                    |           |   \n" *
-        "    5 ——□———————————x———————————x———\n"
+        "    1 ————————•—————x————[Ry]———x—————□———\n" *
+        "              |     |           |         \n" *
+        "    2 ———————[Rx]———•————[Pϕ]———x—————□———\n" *
+        "              |     |                 |   \n" *
+        "    3 —[H ]——————————————[Rθ]——[S ]———————\n" *
+        "              |     |                 |   \n" *
+        "    4 ————————•—————•———————————•—————□———\n" *
+        "                    |           |     |   \n" *
+        "    5 ——————————————x——————————[T†]———□———\n"
 
     io = IOBuffer()
     show(io, cgc)

--- a/test/test_view.jl
+++ b/test/test_view.jl
@@ -7,20 +7,19 @@ using Qaintessent
 
     N = 5
     A = [1 0; 0 -1]
-    MG = kron(A, kron(A, A))
 
     cgc = CircuitGateChain{N}([
-    single_qubit_circuit_gate(3, HadamardGate(), N),
-    controlled_circuit_gate((1, 4), 2, RxGate(√0.2), N),
-    controlled_circuit_gate((2,4), (1,5), SwapGate(), N),
-    single_qubit_circuit_gate(2, PhaseShiftGate(0.2π), N),
-    single_qubit_circuit_gate(3, RotationGate(0.1π, [1, 0, 0]), N),
-    single_qubit_circuit_gate(1, RyGate(1.4π), N),
-    two_qubit_circuit_gate(1,2, SwapGate(), N),
-    controlled_circuit_gate(4, 5, TdagGate(), N),
-    single_qubit_circuit_gate(3, SGate(), N),
-    single_qubit_circuit_gate(1, MatrixGate(A), N),
-    CircuitGate{3,N,AbstractGate{3}}((2, 4, 5), MatrixGate(MG))
+        single_qubit_circuit_gate(3, HadamardGate(), N),
+        controlled_circuit_gate((1, 4), 2, RxGate(√0.2), N),
+        controlled_circuit_gate((2,4), (1,5), SwapGate(), N),
+        single_qubit_circuit_gate(2, PhaseShiftGate(0.2π), N),
+        single_qubit_circuit_gate(3, RotationGate(0.1π, [1, 0, 0]), N),
+        single_qubit_circuit_gate(1, RyGate(1.4π), N),
+        two_qubit_circuit_gate(1,2, SwapGate(), N),
+        controlled_circuit_gate(4, 5, TdagGate(), N),
+        single_qubit_circuit_gate(3, SGate(), N),
+        single_qubit_circuit_gate(1, MatrixGate(A), N),
+        CircuitGate{3,N,AbstractGate{3}}((2, 4, 5), MatrixGate(kron(A, A, A)))
     ])
 
     cgc_refstring =
@@ -38,7 +37,6 @@ using Qaintessent
     io = IOBuffer()
     show(io, cgc)
     @test String(take!(io)) == cgc_refstring
-
 end
 
 
@@ -73,7 +71,6 @@ end
     io = IOBuffer()
     show(io, cgc)
     @test String(take!(io)) == cgc_refstring
-
 end
 
 @testset ExtendedTestSet "test view moments" begin
@@ -164,10 +161,10 @@ end
         controlled_circuit_gate((2), (4), HadamardGate(), N),
         single_qubit_circuit_gate(1, RyGate(1.4π), N)])
     m_refstring =
-    "CircuitGate{1,5,PhaseShiftGate}((5,), PhaseShiftGate([0.6283185307179586]))\n" *
-    "CircuitGate{1,5,RotationGate}((3,), RotationGate([0.3141592653589793, 0.0, 0.0]))\n" *
-    "CircuitGate{2,5,ControlledGate{1,2}}((2, 4), ControlledGate{1,2}(HadamardGate()))\n" *
-    "CircuitGate{1,5,RyGate}((1,), RyGate([4.39822971502571]))\n"
+        "CircuitGate{1,5,PhaseShiftGate}((5,), PhaseShiftGate([0.6283185307179586]))\n" *
+        "CircuitGate{1,5,RotationGate}((3,), RotationGate([0.3141592653589793, 0.0, 0.0]))\n" *
+        "CircuitGate{2,5,ControlledGate{1,2}}((2, 4), ControlledGate{1,2}(HadamardGate()))\n" *
+        "CircuitGate{1,5,RyGate}((1,), RyGate([4.39822971502571]))\n"
 
     io = IOBuffer()
     show(io, m)


### PR DESCRIPTION
I was adding MatrixGate's to a circuit for testing something and the circuit view failed because of not having a general view defined. I added a view for an AbstractGate as -□-.