### PR TITLE
Make ccntrl an optional argument for gates

### DIFF
--- a/test/test_graphs.jl
+++ b/test/test_graphs.jl
@@ -33,9 +33,9 @@ using Qaintessent
 
     cgc_refstring =
         "\n" *
-        "    1 —[X ]—————————————\n" *
+        "    2 ——•————[Z ]——[Y ]—\n" *
         "        |               \n" *
-        "    2 ——•————[Z ]——[Y ]—\n"
+        "    1 —[X ]—————————————\n"
 
     io = IOBuffer()
     show(io, cgc)


### PR DESCRIPTION
This is to prevent failure when creating CircuitGates
CircuitGates have constructors of the form:

CircuitGate(iwires, gate; ccntrl=...). The `;` corresponds to required keyword arguments. These must be optional arguments with default parameters for greater flexibility. Changing the `;` to `,`.