### PR TITLE
Measurement ops

### DIFF
--- a/src/apply.jl
+++ b/src/apply.jl
@@ -9,6 +9,13 @@ function sliced_index(idx, targetwires, N)
     return islice
 end
 
+"""
+    apply(m::AbstractMatrix, ψ::AbstractVector)
+
+"""
+function apply(m::AbstractMatrix, ψ::AbstractVector)
+    return m*Vector(ψ)
+end
 
 """
     apply(cg::CircuitGate{M,N,G}, ψ::AbstractVector) where {M,N,G}
@@ -241,8 +248,9 @@ end
 returns list of expectation values from measurement operators in `c.meas` after applying circuit gates in `c.cgc` on state vector of `N` qubits `ψ`
 """
 function apply(c::Circuit{N}, ψ::AbstractVector{<:Complex}) where {N}
-    ψs = apply(c.cgc, ψ)
-    return [real(dot(ψs, m*ψs)) for m in c.meas.mops]
+    ψl = apply(c.cgc, ψ)
+    ψr = apply.(c.meas.mops, (ψl,))
+    return real.(dot.((ψl,), ψr))
 end
 
 (c::Circuit)(ψ) = apply(c, ψ)

--- a/src/circuit.jl
+++ b/src/circuit.jl
@@ -675,8 +675,7 @@ end
 Pairwise commuting measurement operators (Hermitian matrices) for circuit of size `N`.
 """
 struct MeasurementOps{N}
-    mops::AbstractVector{<:AbstractMatrix}
-    cgs::AbstractVector{<:CircuitGate}
+    mops::AbstractVector
 
     @doc """
         MeasurementOps{N}(mop::AbstractMatrix) where {N}
@@ -723,7 +722,7 @@ struct MeasurementOps{N}
         mop = matrix(cg)
         size(mop) == (d^N, d^N) || error("Measurement operator must be a 2^N × 2^N matrix.")
         mop ≈ Base.adjoint(mop) || error("Measurement operator must be Hermitian.")
-        new([mop], [cg])
+        new([cg])
     end
 
     @doc """
@@ -739,14 +738,13 @@ struct MeasurementOps{N}
         for cg in cgs
             push!(mops, matrix(cg))
         end
-        for m in mops
-            size(m) == (d^N, d^N) || error("Measurement operator must be a 2^N × 2^N matrix.")
-            m ≈ Base.adjoint(m) || error("Measurement operator must be Hermitian.")
-            for n in mops
-                norm(comm(m, n))/d^N < 1e-13 || error("Measurement operators must pairwise commute.")
+        for cg in cgs
+            cg ≈ adjoint(cg) || error("Measurement operator must be Hermitian.")
+            for cg2 in cgs
+                iscommuting(cg, cg2) || error("Measurement operators must pairwise commute.")
             end
         end
-        new(mops, cgs)
+        new(cgs)
     end
 
 end


### PR DESCRIPTION
Update MeasurementOps to use arbitrary CG/Abstract matrix as Measurement operators. This allows flexibility when creating MeasOps -and- may fixed #undef error in Qaintellect.jl