### PR TITLE
Update Qaintessent view to allow creating empty Vector{CircuitGate} o…

### DIFF
--- a/src/view.jl
+++ b/src/view.jl
@@ -148,6 +148,10 @@ function Base.show(io::IO, m::Moment)
 end
 
 function Base.show(io::IO, cgs::Vector{<:CircuitGate}, N::Union{Nothing,Int}=nothing)
+    if isempty(cgs)
+        println(io, "[]")
+        return
+    end
     if isnothing(N)
         N = maximum(req_wires.(cgs))
     end


### PR DESCRIPTION
Update view.jl. Fixed bug that prevents printing of empty Vector{CircuitGate}