### PR TITLE
Replace invpermute!! with invpermute!

### DIFF
--- a/src/apply_statevector.jl
+++ b/src/apply_statevector.jl
@@ -1,6 +1,3 @@
-using Base
-using Base: invpermute!!
-
 """Modifies perm vector in Statevector object to flip qubit at position `wire`"""
 function flipqubit!(ψ::Statevector, wire::Int)
     @simd for i in 1:length(ψ)
@@ -133,7 +130,7 @@ function _apply!(ψ::Statevector, cg::CircuitGate{1,HadamardGate})
         @inbounds ψ.state[mid+1:2mid] .*= -1
         @inbounds ψ.state[mid+1:2mid] .+= ψ.vec[1:mid]
 
-        @inbounds invpermute!!(ψ.state, ψ.perm)
+        @inbounds invpermute!(ψ.state, ψ.perm)
         resetpermute!(ψ)
     end
     return
@@ -240,7 +237,7 @@ function _apply!(ψ::Statevector, cg::CircuitGate{1,T}) where {T<:AbstractGate}
         @inbounds ψ.state[1:mid] .+= ψ.vec[1:mid]
         @inbounds mul!(ψ.vec[1:mid], U[2,2], ψ.vec[mid+1:end])
         @inbounds ψ.state[mid+1:mid+mid] .+= ψ.vec[1:mid]
-        @inbounds invpermute!!(ψ.state, ψ.perm)
+        @inbounds invpermute!(ψ.state, ψ.perm)
         resetpermute!(ψ)
     end 
     return
@@ -269,7 +266,7 @@ function _apply!(ψ::Statevector, cg::CircuitGate{M,ControlledGate{G}}) where {M
     start = length(ψ) - 2^(ψ.N-C) + 1
     ψ.vec[start:end] .= _apply(ψ.vec[start:end], new_cg, ψ.N-C)
     @inbounds ψ.state .= ψ.vec
-    @inbounds invpermute!!(ψ.state, ψ.perm)
+    @inbounds invpermute!(ψ.state, ψ.perm)
     resetpermute!(ψ)
     return
 end
@@ -314,7 +311,7 @@ function _apply!(ψ::Statevector, cg::CircuitGate{M,G}) where {M,G}
                 @inbounds ψ.state[(i-1)*step+1:i*step] .+= ψ.vec[1:step]
             end
         end
-        @inbounds invpermute!!(ψ.state, ψ.perm)
+        @inbounds invpermute!(ψ.state, ψ.perm)
         resetpermute!(ψ)
     end
 end

--- a/src/gpu/apply_gpu.jl
+++ b/src/gpu/apply_gpu.jl
@@ -1,5 +1,3 @@
-using Base
-using Base: invpermute!!
 using Qaintessent
 using CUDA
 


### PR DESCRIPTION
This stops using the undocumented and therefore internal method `Base.invpermute!!` which may be removed from Base in 1.10. It also increases performance by up to 10x for large numbers of qbits at the cost of a decrease in performance up to 3x for few qbits.

benchmarking code
```julia
using BenchmarkTools, Random, Plots

old(state, perm) = @inbounds Base.invpermute!!(state, perm)
new(state, perm) = invpermute!(state, perm)

function time(func, n)
    s = rand(ComplexF64, n)
    p = randperm(n)
    p_buf = copy(p)
    @belapsed $func($s, copyto!($p_buf, $p)) setup=(randperm!($p); rand!($s))
end

x = 2 .^ (1:25)
y_old = [time(old, n) for n in x]
y_new = [time(new, n) for n in x]

plot(log2.(x), y_old ./ x, label="old")
plot!(log2.(x), y_new ./ x, label="new")
plot!(xlabel="N", yaxis=:log10, legend=:topleft, ylabel="seconds/2^N")
```
Result
<img width="591" alt="Screenshot 2023-05-15 at 5 22 37 PM" src="https://github.com/Qaintum/Qaintessent.jl/assets/60898866/86e09b82-5346-431b-beea-802bcb44d54c">

